### PR TITLE
Adding support for `subgroup` option.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tmplr/core",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tmplr/core",
-      "version": "0.7.3",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "change-case": "^4.1.2",

--- a/src/command/degit.ts
+++ b/src/command/degit.ts
@@ -10,7 +10,7 @@ export class DegitExecution extends ChangeExecution {
   async commit() {
     const source = await this.delegate(this.degit.source.run(this.flow))
     const target = await this.delegate(this.degit.target.run(this.flow))
-    await this.degit.filesystem.fetch(source, target)
+    await this.degit.filesystem.fetch(source, target, { subgroup: this.degit.options.subgroup })
 
     return { source, target }
   }
@@ -18,6 +18,7 @@ export class DegitExecution extends ChangeExecution {
 
 
 export interface DegitExtras {
+  subgroup?: boolean
   log?: ChangeLog
 }
 

--- a/src/command/test/degit.test.ts
+++ b/src/command/test/degit.test.ts
@@ -31,7 +31,7 @@ describe(Degit, () => {
       { log }
     ).run(new Flow({ onKill: jest.fn() })).execute()
 
-    expect(dummyFS.fetch).toHaveBeenCalledWith('some:repo', 'some/path')
+    expect(dummyFS.fetch).toHaveBeenCalledWith('some:repo', 'some/path', { subgroup: undefined })
     expect(log.entries()[0]!.details['source']).toBe('some:repo')
     expect(log.entries()[0]!.details['target']).toBe('some/path')
   })
@@ -58,6 +58,37 @@ describe(Degit, () => {
       dummyFS,
     ).run(new Flow({ onKill: jest.fn() })).execute()
 
-    expect(dummyFS.fetch).toHaveBeenCalledWith('some:repo', 'some/path')
+    expect(dummyFS.fetch).toHaveBeenCalledWith('some:repo', 'some/path', { subgroup: undefined })
   })
+
+  test('supports subgroup option.', async () => {
+    const dummyFS: FileSystem = {
+      read: jest.fn(),
+      write: jest.fn(),
+      absolute: jest.fn(),
+      basename: jest.fn(),
+      dirname: jest.fn(),
+      ls: jest.fn(),
+      rm: jest.fn(),
+      access: jest.fn(),
+      fetch: jest.fn(),
+      cd: jest.fn(),
+      scope: 'scope',
+      root: 'root',
+    }
+
+    const log = new ChangeLog()
+
+    await new Degit(
+      new Value('some:repo/group'),
+      new Value('some/path'),
+      dummyFS,
+      { log, subgroup: true }
+    ).run(new Flow({ onKill: jest.fn() })).execute()
+
+    expect(dummyFS.fetch).toHaveBeenCalledWith('some:repo/group', 'some/path', { subgroup: true })
+    expect(log.entries()[0]!.details['source']).toBe('some:repo/group')
+    expect(log.entries()[0]!.details['target']).toBe('some/path')
+  })
+
 })

--- a/src/filesystem/types.ts
+++ b/src/filesystem/types.ts
@@ -1,3 +1,8 @@
+export interface FetchOptions {
+  subgroup ?: boolean
+}
+
+
 export interface FileSystem {
   read(path: string): Promise<string>
   write(path: string, content: string): Promise<void>
@@ -12,7 +17,7 @@ export interface FileSystem {
   cd(path: string): FileSystem
   ls(path: string): Promise<string[]>
 
-  fetch(remote: string, dest: string): Promise<void>
+  fetch(remote: string, dest: string, options?: FetchOptions): Promise<void>
 }
 
 


### PR DESCRIPTION
As per the list [here](https://github.com/loreanvictor/tmplr-node/pull/2#issuecomment-2210493485), adding the following to support a new `subgroup` option to allow for GitLab subgroups to be checked out correctly with `tmplr`.

This does the following from that checklist:

* [X] adds the newly added options to the [filesystem type](https://github.com/loreanvictor/tmplr-core/blob/0ca3badc23658583da9cdedcfdb032256376b7a0/src/filesystem/types.ts#L15)
* [x] adds subgroup option for [degit command](https://github.com/loreanvictor/tmplr-core/blob/main/src/command/degit.ts)