### PR TITLE
Fix execute finalization

### DIFF
--- a/src/execution.ts
+++ b/src/execution.ts
@@ -38,10 +38,11 @@ export abstract class Execution<T> {
 
   public async execute(): Promise<T> {
     this.start()
-    const result = await this.run()
-    this.end()
-
-    return result
+    try {
+      return await this.run()
+    } finally {
+      this.end()
+    }
   }
 
   public trace() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ export * from './execution'
 export * from './deferred'
 export * from './io'
 export * from './runnable'
-export * from './runnable'
 export * from './sandbox'
 export * from './flow'
 


### PR DESCRIPTION
## Summary
- ensure `Execution` cleanup runs even when `run()` throws
- remove duplicate export from index

## Testing
- `npx jest --version` *(fails: connect EHOSTUNREACH)*